### PR TITLE
修复有时候任务倒计时会停在 00:01不再继续，只能手动停止的bug

### DIFF
--- a/js/alloy.timer.js
+++ b/js/alloy.timer.js
@@ -123,6 +123,8 @@ Jx().$package(function(J){
 			if(remainTime === 0){
 				timeComing();
 			}
+		}else {
+			timeComing();
 		}
 
 	}


### PR DESCRIPTION
如Issues中，大家反馈的